### PR TITLE
Move Riverpod listeners to lifecycle-safe hooks

### DIFF
--- a/lib/features/loading/view/loading_screen.dart
+++ b/lib/features/loading/view/loading_screen.dart
@@ -30,10 +30,20 @@ class LoadingScreen extends ConsumerStatefulWidget {
 }
 
 class _LoadingScreenState extends ConsumerState<LoadingScreen> {
+  late final ProviderSubscription<InitializationState>
+      _initializationListener;
+
   @override
   void initState() {
     super.initState();
     AppLogger.d('Initializing LoadingScreen UI');
+
+    _initializationListener = ref.listenManual(
+      initializationProvider,
+      (previous, next) {
+        // Reserved for initialization state transitions if needed.
+      },
+    );
 
     // Post-frame callback ensures context is available for checks
     WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -47,12 +57,13 @@ class _LoadingScreenState extends ConsumerState<LoadingScreen> {
   }
 
   @override
-  Widget build(BuildContext context) {
-    ref.listen(initializationProvider, (previous, next) {
-      // if (next.status == InitializationStatus.success) {
-      // }
-    });
+  void dispose() {
+    _initializationListener.close();
+    super.dispose();
+  }
 
+  @override
+  Widget build(BuildContext context) {
     final initState = ref.watch(initializationProvider);
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;


### PR DESCRIPTION
### Motivation
- Eliminate side-effects from widget `build` methods by registering Riverpod listeners in lifecycle-safe locations to avoid multiple registrations and rebuild-time work.
- Ensure UI side-effects (snackbars, initialization transitions, and watchlist fetches) are performed once per widget lifecycle and cleaned up correctly.

### Description
- In `lib/features/home/view/home_screen.dart` moved the `ref.listen(newsProvider, ...)` logic out of `build` into `initState` using `ref.listenManual` and closed the subscription in `dispose`, preserving the existing snackbar behavior. 
- Converted `_WatchlistHomeSection` from a `ConsumerWidget` into a `ConsumerStatefulWidget` and added `_fetchListIfNeeded` triggered from `initState` and `didUpdateWidget`, removing the `Future.microtask` side-effect from `build`. 
- In `lib/features/loading/view/loading_screen.dart` removed the no-op `ref.listen` from `build` and added a lifecycle-managed `ref.listenManual(initializationProvider, ...)` in `initState` with disposal in `dispose` so the listener is registered once per lifecycle. 
- Kept all user-visible behaviors (snackbars, fetch logic, initialization flow) unchanged while making the listener registration lifecycle-safe.

### Testing
- Ran `git diff --check` which reported no issues after trimming trailing whitespace and the changes were committed successfully. 
- Attempted `dart format` and `flutter format` but both tools are unavailable in the environment so formatting could not be validated automatically. 
- No unit or integration tests were executed in this environment; changes are limited to listener placement and lifecycle handling and were validated via repository diffs and local compilation-friendly edits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698903a447ac83289f66cc1776792ddf)