### PR TITLE
Fix release workflow tag resolution and YAML parsing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,16 +33,90 @@ on:
         type: boolean
         default: false
       tag_name:
-        description: "Release tag ('latest' for newest release, 'main' for latest commit, or specific tag)"
+        description: "Release tag ('auto' from pubspec.yaml, 'latest', 'main', or a specific tag)"
         type: string
-        default: "latest"
+        default: "auto"
 
 permissions:
   contents: write
 
-# ---------------- ANDROID ----------------
 jobs:
+  resolve-release-tag:
+    runs-on: ubuntu-latest
+    outputs:
+      tag_name: ${{ steps.resolve.outputs.tag_name }}
+      is_prerelease: ${{ steps.resolve.outputs.is_prerelease }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve release tag
+        id: resolve
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REQUESTED_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag_name || github.ref_name }}
+          INPUT_IS_PRERELEASE: ${{ github.event_name == 'workflow_dispatch' && inputs.is_prerelease || false }}
+        run: |
+          set -euo pipefail
+          git fetch --tags --force
+
+          requested="${REQUESTED_TAG:-auto}"
+          requested="$(echo "$requested" | xargs)"
+
+          tag_exists_or_released() {
+            local tag="$1"
+            git rev-parse -q --verify "refs/tags/$tag" >/dev/null || gh release view "$tag" >/dev/null 2>&1
+          }
+
+          latest_alpha_for_base() {
+            local prefix="$1"
+            {
+              git tag --list "${prefix}-alpha.*"
+              gh release list --limit 200 --json tagName -q '.[].tagName' 2>/dev/null || true
+            } | sed -n "s/^$(printf '%s' "$prefix" | sed 's/[.[\*^$()+?{}|\\]/\\&/g')-alpha\.\([0-9][0-9]*\)$/\1/p" | sort -n | tail -1
+          }
+
+          if [ "${{ github.event_name }}" = "push" ]; then
+            resolved="$GITHUB_REF_NAME"
+          elif [ -z "$requested" ] || [ "$requested" = "auto" ]; then
+            version="$(awk '/^version:[[:space:]]*/ {print $2; exit}' pubspec.yaml | cut -d+ -f1)"
+            if [ -z "$version" ]; then
+              echo "Could not read version from pubspec.yaml" >&2
+              exit 1
+            fi
+
+            base_tag="v$version"
+            if tag_exists_or_released "$base_tag"; then
+              major_minor="${version%.*}"
+              patch="${version##*.}"
+              next_patch=$((patch + 1))
+              alpha_base="v${major_minor}.${next_patch}"
+              last_alpha="$(latest_alpha_for_base "$alpha_base")"
+              if [ -z "$last_alpha" ]; then
+                resolved="${alpha_base}-alpha.1"
+              else
+                resolved="${alpha_base}-alpha.$((last_alpha + 1))"
+              fi
+            else
+              resolved="$base_tag"
+            fi
+          else
+            resolved="$requested"
+          fi
+
+          prerelease="$INPUT_IS_PRERELEASE"
+          case "$resolved" in
+            v*-*) prerelease="true" ;;
+          esac
+
+          echo "Resolved release tag: $resolved"
+          echo "tag_name=$resolved" >> "$GITHUB_OUTPUT"
+          echo "is_prerelease=$prerelease" >> "$GITHUB_OUTPUT"
+
+  # ---------------- ANDROID ----------------
   build-android:
+    needs: resolve-release-tag
     if: github.event_name == 'push' || github.event.inputs.build_android == 'true'
     runs-on: ubuntu-latest
 
@@ -69,7 +143,7 @@ jobs:
 
       - name: Create key.properties
         run: |
-          cat <<EOF > android/key.properties
+          cat > android/key.properties <<EOF
           storePassword=${{ secrets.ANDROID_STORE_PASSWORD }}
           keyPassword=${{ secrets.ANDROID_KEY_PASSWORD }}
           keyAlias=${{ secrets.ANDROID_KEY_ALIAS }}
@@ -78,7 +152,7 @@ jobs:
 
       - name: Create env file
         run: |
-          cat <<EOF > keys.json
+          cat > keys.json <<EOF
           {
             "ANILIST_CLIENT_ID": "${{ secrets.ANILIST_CLIENT_ID }}",
             "ANILIST_CLIENT_SECRET": "${{ secrets.ANILIST_CLIENT_SECRET }}",
@@ -90,7 +164,8 @@ jobs:
 
       - run: find . -name "pubspec.lock" -type f -delete && flutter pub upgrade
 
-      - run: flutter build apk --release --split-per-abi
+      - run: >-
+          flutter build apk --release --split-per-abi
           --dart-define-from-file=keys.json
 
       - uses: actions/upload-artifact@v4
@@ -100,6 +175,7 @@ jobs:
 
   # ---------------- LINUX ----------------
   build-linux:
+    needs: resolve-release-tag
     if: github.event_name == 'push' || github.event.inputs.build_linux == 'true'
     runs-on: ubuntu-latest
 
@@ -123,7 +199,7 @@ jobs:
 
       - name: Create env file
         run: |
-          cat <<EOF > keys.json
+          cat > keys.json <<EOF
           {
             "ANILIST_CLIENT_ID": "${{ secrets.ANILIST_CLIENT_ID }}",
             "ANILIST_CLIENT_SECRET": "${{ secrets.ANILIST_CLIENT_SECRET }}",
@@ -135,7 +211,7 @@ jobs:
 
       - run: flutter config --enable-linux-desktop
       - run: find . -name "pubspec.lock" -type f -delete && flutter pub upgrade
-     
+
       - run: flutter build linux --release --dart-define-from-file=keys.json
       - uses: actions/upload-artifact@v4
         with:
@@ -144,6 +220,7 @@ jobs:
 
   # ---------------- WINDOWS ----------------
   build-windows:
+    needs: resolve-release-tag
     if: github.event_name == 'push' || github.event.inputs.build_windows == 'true'
     runs-on: windows-2022
 
@@ -163,14 +240,17 @@ jobs:
         run: flutter config --enable-windows-desktop
 
       - name: Create env file
+        shell: bash
         run: |
-          echo '{
+          cat > keys.json <<EOF
+          {
             "ANILIST_CLIENT_ID": "${{ secrets.ANILIST_CLIENT_ID }}",
             "ANILIST_CLIENT_SECRET": "${{ secrets.ANILIST_CLIENT_SECRET }}",
             "MAL_CLIENT_ID": "${{ secrets.MAL_CLIENT_ID }}",
             "MAL_CLIENT_SECRET": "${{ secrets.MAL_CLIENT_SECRET }}",
             "COMMENTUM_API_URL": "${{ secrets.COMMENTUM_API_URL }}"
-          }' > keys.json
+          }
+          EOF
 
       - run: flutter pub upgrade
 
@@ -186,13 +266,13 @@ jobs:
 
   # ---------------- NOTIFY ----------------
   notify:
-    needs: [build-android, build-linux, build-windows]
+    needs: [resolve-release-tag, build-android, build-linux, build-windows]
     if: always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && (github.event_name == 'push' || github.event.inputs.notify_discord == 'true')
-    uses: ./.github/workflows/notify_release.yaml
+    uses: ./.github/workflows/Notify.yml
     with:
       notify_everyone: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.notify_everyone == 'true' || true }}
       include_logs: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.include_logs == 'true' || true }}
-      is_prerelease: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.is_prerelease == 'true' || false }}
-      tag_name: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag_name || 'latest' }}
+      is_prerelease: ${{ needs.resolve-release-tag.outputs.is_prerelease == 'true' }}
+      tag_name: ${{ needs.resolve-release-tag.outputs.tag_name }}
     secrets:
       DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}


### PR DESCRIPTION
### Motivation
- Prevent release runs from failing when a requested tag does not exist by resolving/creating a sensible tag instead of falling back to previous releases. 
- Provide an `auto` mode which derives the release version from `pubspec.yaml` and bumps to a safe prerelease tag when the base version is already released. 
- Fix YAML parsing issues in the workflow that caused the release build to fail (multiline command/heredoc formatting). 

### Description
- Change the `workflow_dispatch` default `tag_name` to `auto` and add a new `resolve-release-tag` job that computes the final `tag_name` and `is_prerelease` outputs. 
- `resolve-release-tag` reads `version` from `pubspec.yaml`, checks existing git tags and GitHub releases, and if the base tag is already released it increments to the next `vX.Y.Z-alpha.N` tag (picking the next available `alpha.N`). 
- Preserve explicitly supplied tags (even if they do not exist yet) so the release creation step can create them rather than failing, and auto-mark tags with a hyphen (e.g., prerelease-like strings) as prereleases. 
- Wire other jobs to depend on the resolver by adding `needs: resolve-release-tag`, fix YAML heredocs and fold the multiline `flutter build apk` command to avoid parsing problems, and point the notify job to the existing `.github/workflows/Notify.yml` while passing the resolved tag outputs. 

### Testing
- Verified workflow YAML parseability with Ruby using `ruby -e 'require "yaml"; ARGV.each{|f| YAML.load_file(f); puts "#{f} ok"}' .github/workflows/release.yaml .github/workflows/Notify.yml`, which succeeded. 
- Validated the resolver script syntax with `bash -n` by extracting the `run` block and performing a no-exec syntax check, which succeeded. 
- Ran `git diff --check` to ensure no trailing-whitespace/patch issues, which reported no problems. 
- Attempted to run `actionlint` but it could not be installed in this environment due to the Go proxy being blocked, so that lint step was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a382d68ffdc8328a9c7d7ce5d7e2870)