### PR TITLE
fix(player): resolve video stream extraction and null-safety in sourc…

### DIFF
--- a/lib/features/player/engine/media_kit/media_kit_engine.dart
+++ b/lib/features/player/engine/media_kit/media_kit_engine.dart
@@ -194,7 +194,19 @@ class MediaKitEngine implements VideoEngine {
       }
     });
 
-    await completer.future;
+    try {
+      await completer.future.timeout(const Duration(seconds: 4));
+    } catch (_) {
+      // Timeout reached before position advanced (e.g. stream buffering/paused), run onReady and proceed
+      if (!handled) {
+        handled = true;
+        await _positionSubscription?.cancel();
+        _positionSubscription = null;
+        try {
+          await onReady();
+        } catch (_) {}
+      }
+    }
   }
 
   @override

--- a/lib/source_engine/adapters/anime_source_adapter.dart
+++ b/lib/source_engine/adapters/anime_source_adapter.dart
@@ -25,7 +25,7 @@ class AnimeSourceAdapter extends BaseSourceAdapter implements AnimeSource {
       return (detail.episodes ?? [])
           .map(
             (e) => UnifiedEpisode(
-              id: '${e.url!}|${e.episodeNumber}',
+              id: '${e.url ?? ''}|${e.episodeNumber}',
               season:
                   e.toMediaInfo()?.season ??
                   _parseSeasonFromScanlator(e.scanlator),
@@ -69,9 +69,9 @@ class AnimeSourceAdapter extends BaseSourceAdapter implements AnimeSource {
     final methodLog = log.child('getSources');
     try {
       methodLog.i('episodeId=$episodeId server=${server.name}');
-      final parts = episodeId.split('|');
-      final url = parts[0];
-      final epNum = parts.length > 1 ? parts[1] : '1';
+      final lastPipe = episodeId.lastIndexOf('|');
+      final url = lastPipe != -1 ? episodeId.substring(0, lastPipe) : episodeId;
+      final epNum = lastPipe != -1 ? episodeId.substring(lastPipe + 1) : '1';
 
       final videos = await source.methods.getVideoList(
         bridge.DEpisode(url: url, episodeNumber: epNum),
@@ -80,13 +80,24 @@ class AnimeSourceAdapter extends BaseSourceAdapter implements AnimeSource {
       methodLog.d('streams=${videos.length}');
 
       return videos
+          .where((e) => e.url.isNotEmpty)
           .map(
             (e) => VideoStream(
               url: e.url,
-              quality: e.title ?? e.quality,
+              quality: (e.title != null && e.title!.isNotEmpty)
+                  ? e.title!
+                  : (e.quality.isNotEmpty ? e.quality : 'Default'),
               headers: e.headers,
               subtitles: (e.subtitles ?? [])
-                  .map((s) => SubtitleTrack(url: s.file!, language: s.label!))
+                  .where((s) => s.file != null && s.file!.isNotEmpty)
+                  .map(
+                    (s) => SubtitleTrack(
+                      url: s.file!,
+                      language: (s.label != null && s.label!.isNotEmpty)
+                          ? s.label!
+                          : 'Sub',
+                    ),
+                  )
                   .toList(),
             ),
           )

--- a/lib/source_engine/adapters/base_source_adapter.dart
+++ b/lib/source_engine/adapters/base_source_adapter.dart
@@ -239,14 +239,15 @@ abstract class BaseSourceAdapter implements MediaSource {
       methodLog.d('Found ${results.list.length} results');
 
       final parsed = results.list
+          .where((e) => e.url != null && e.url!.isNotEmpty)
           .map(
             (e) => UnifiedMedia(
-              id: '${e.url!}|${e.title!}',
+              id: '${e.url ?? ''}|${e.title ?? ''}',
               type: mediaType,
               sourceId: sourceInfo.id,
               sourceName: sourceInfo.name,
-              providerId: e.url!,
-              title: MediaTitle(english: e.title),
+              providerId: e.url ?? '',
+              title: MediaTitle(english: e.title ?? 'Unknown'),
               cover: e.cover,
               description: e.description,
             ),
@@ -279,14 +280,15 @@ abstract class BaseSourceAdapter implements MediaSource {
       methodLog.d('results=${results.list.length}');
 
       final list = results.list
+          .where((e) => e.url != null && e.url!.isNotEmpty)
           .map(
             (e) => UnifiedMedia(
-              id: '${e.url!}|${e.title!}',
+              id: '${e.url ?? ''}|${e.title ?? ''}',
               type: mediaType,
               sourceId: sourceInfo.id,
               sourceName: sourceInfo.name,
-              providerId: e.url!,
-              title: MediaTitle(english: e.title),
+              providerId: e.url ?? '',
+              title: MediaTitle(english: e.title ?? 'Unknown'),
               cover: e.cover,
               description: e.description,
             ),
@@ -322,9 +324,12 @@ abstract class BaseSourceAdapter implements MediaSource {
     final cached = _cache.get<bridge.DMedia>(cacheKey);
     if (cached != null) return cached;
 
-    final parts = providerId.split('|');
+    final lastPipe = providerId.lastIndexOf('|');
+    final url = lastPipe != -1 ? providerId.substring(0, lastPipe) : providerId;
+    final title = lastPipe != -1 ? providerId.substring(lastPipe + 1) : '';
+
     final detail = await source.methods.getDetail(
-      bridge.DMedia(url: parts[0], title: parts.length > 1 ? parts[1] : ''),
+      bridge.DMedia(url: url, title: title),
     );
     _cache.set(cacheKey, detail);
     return detail;
@@ -342,14 +347,15 @@ abstract class BaseSourceAdapter implements MediaSource {
 
       final extraInfo = detail.toMediaInfo();
 
-      final parts = providerId.split('|');
+      final lastPipe = providerId.lastIndexOf('|');
+      final url = lastPipe != -1 ? providerId.substring(0, lastPipe) : providerId;
       final parsed = UnifiedMedia(
         id: providerId,
         type: mediaType,
         idMal: extraInfo?.malId?.toString(),
         sourceId: sourceInfo.id,
         sourceName: sourceInfo.name,
-        providerId: parts[0],
+        providerId: url,
         title: MediaTitle(english: detail.title),
         cover: detail.cover,
         description: detail.description,

--- a/lib/source_engine/adapters/manga_source_adapter.dart
+++ b/lib/source_engine/adapters/manga_source_adapter.dart
@@ -23,7 +23,7 @@ class MangaSourceAdapter extends BaseSourceAdapter implements MangaSource {
       return (detail.episodes ?? [])
           .map(
             (e) => UnifiedChapter(
-              id: '${e.url!}|${e.episodeNumber}',
+              id: '${e.url ?? ''}|${e.episodeNumber}',
               title: e.name,
               number: double.tryParse(e.episodeNumber) ?? 0.0,
               scanlator: e.scanlator,
@@ -42,9 +42,9 @@ class MangaSourceAdapter extends BaseSourceAdapter implements MangaSource {
     final methodLog = log.child('getPages');
     try {
       methodLog.i('chapterId=$chapterId');
-      final parts = chapterId.split('|');
-      final url = parts[0];
-      final epNum = parts.length > 1 ? parts[1] : '1';
+      final lastPipe = chapterId.lastIndexOf('|');
+      final url = lastPipe != -1 ? chapterId.substring(0, lastPipe) : chapterId;
+      final epNum = lastPipe != -1 ? chapterId.substring(lastPipe + 1) : '1';
 
       final pages = await source.methods.getPageList(
         bridge.DEpisode(url: url, episodeNumber: epNum),
@@ -54,7 +54,8 @@ class MangaSourceAdapter extends BaseSourceAdapter implements MangaSource {
       return pages.map((e) {
         final headers = {
           ...(e.headers ?? {}),
-          'referer': '${sourceInfo.baseUrl}/',
+          if (sourceInfo.baseUrl != null && sourceInfo.baseUrl!.isNotEmpty)
+            'referer': '${sourceInfo.baseUrl}/',
           'user-agent':
               'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Safari/537.36',
         };


### PR DESCRIPTION
### Summary of Changes
- **Source Adapters**:
  - Replaced fragile `split('|')` with `lastIndexOf('|')` in `anime_source_adapter.dart`, `manga_source_adapter.dart`, and `base_source_adapter.dart` to prevent truncating URLs containing pipes or query parameters.
  - Added null-safe checks for `e.url` and subtitle mapping to prevent `Null check operator` crashes during stream extraction.
- **Player Engine**:
  - Added a 4-second safety timeout in `MediaKitEngine._waitUntilReady` to prevent player initialization from hanging when position does not advance immediately.
